### PR TITLE
Warmer sends email when some URL is not accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ The script will provide a JSON output with stats about the crawl, example:
 }
 ```
 
+#### Reporting unaccessible pages
+You can set up mail alert when some URLs cannot be accessed. Just modify your `config.php` like this:
+```php
+<?php
+return array(
+    'key' => '9f316c95a356aab49cf5e4fcf3418295' // Secret key to allow traversing sitemaps
+    'reportProblematicUrls' => true,
+    'reportProblematicUrlsTo' => "your-address@example.com"
+);
+```
+
+URL is reported whencannot be opened with `file_get_contents()`. Proper handling of status codes will be added soon.
+
 #### Using the CLI
 
 Also you can launch the script from the CLI to bypass the common errors of timeout (504) from an Nginx server.


### PR DESCRIPTION
Hi, I added new feature to your warmer - when file_get_contents() ends with error (returns false), URL can be saved and user can be notified about it via email. I'm working on curl reimplementation for proper handling of status codes (so this tool can be used for looking over dead pages too).